### PR TITLE
Connect contact form to FormSubmit endpoint

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -80,7 +80,7 @@
         </div>
       </div>
       <div class="col-md-6">
-        <form class="card card-quiet p-4 h-100" method="post" action="https://formspree.io/f/your-id">
+        <form class="card card-quiet p-4 h-100" method="post" action="https://formsubmit.co/72454dc64b76a4c87bccd219447044de">
           <h2 class="h6 text-uppercase text-muted">Send a message</h2>
           <div class="mb-3">
             <label for="name" class="form-label">Name</label>
@@ -94,11 +94,16 @@
             <label for="message" class="form-label">Message</label>
             <textarea required class="form-control" id="message" name="message" rows="4"></textarea>
           </div>
+          <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" value="agree" id="privacyConsent" name="privacy_consent" required>
+            <label class="form-check-label" for="privacyConsent">
+              I agree to the <a href="/privacy.html">privacy policy</a> and consent to having Good Hope Corp store my submitted information so they can respond to my enquiry.
+            </label>
+          </div>
           <div class="d-flex gap-2">
             <button type="submit" class="btn btn-primary">Send</button>
             <a class="btn btn-outline-primary" href="mailto:contact@goodhopecorp.com?subject=Enquiry">Use email</a>
           </div>
-          <p class="small text-muted mt-3 mb-0">This form uses Formspree. Replace the action with your own endpoint or CRM.</p>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- point the contact form at an activated FormSubmit endpoint so submissions deliver to the inbox
- add a required privacy-policy consent checkbox and remove the placeholder helper text

## Testing
- curl -s -X POST https://formsubmit.co/ajax/72454dc64b76a4c87bccd219447044de -H 'Content-Type: application/json' -H 'Referer: https://goodhopecorp.com/contact.html' -d '{"name":"Smoke Test","email":"ghcxk4542l1@powerscrews.com","message":"AJAX smoke test","privacy_consent":"agree"}'
- curl -s https://api.mail.tm/messages/68ca9ec7be493bc99b21c7db -H 'Authorization: Bearer ***'

------
https://chatgpt.com/codex/tasks/task_e_68ca9dbe92ec832986e0e88ab79ef1a4